### PR TITLE
Missing dependency on Dist::ZIlla causing smoker failures.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,7 @@ Text::Wrap        = 2006.1117
 Git::Repository   = 1.22
 Software::Release = 0.01
 DateTime          = 0.66
+Dist::Zilla       = 4
 
 [MetaResources]
 bugtracker        = http://rt.cpan.org/Public/Dist/Display.html?Name=Dist-Zilla-Plugin-ChangelogFromGit


### PR DESCRIPTION
I just released dzp::ChangelogFromGit::CPAN::Changes, which extends this module.

The first smoke tests are unfortunately bringing failures [see http://www.cpantesters.org/cpan/report/0594e22c-3d69-11e1-9d6f-f6dbfa7543f5] which seem to be due to a missing Moose::Autobox, which is required by Dist::Zilla, which is required by you, which is required by me :-)
