### PR TITLE
Update lib/Dist/Zilla/Plugin/ChangelogFromGit.pm

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangelogFromGit.pm
+++ b/lib/Dist/Zilla/Plugin/ChangelogFromGit.pm
@@ -179,7 +179,7 @@ sub gather_files {
 
 				next if (
 					defined $include_message_re and
-					$log->message() =~ /$include_message_re/o
+					$log->message() !~ /$include_message_re/o
 				);
 
 				#print STDERR "LOG: ".$log->message."\n";


### PR DESCRIPTION
log messages should be skipped if there is a include_message_re and the message _DOESN'T_ match the include_message_re.
