### PR TITLE
avoid warning by initializing $buf

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangelogFromGit.pm
+++ b/lib/Dist/Zilla/Plugin/ChangelogFromGit.pm
@@ -406,7 +406,7 @@ sub format_datetime {
 
 sub rungit {
 	my ($self, $arrayp) = @_;
-	my $buf;
+	my $buf = '';
 	run(command => $arrayp, buffer => \$buf);
 	return split("\n", $buf);
 }


### PR DESCRIPTION
Ah this module saves so much work, thanks! Noticed a warning:

`Use of uninitialized value $buf in split at ... Dist/Zilla/Plugin/ChangelogFromGit.pm line 411.`
