### PR TITLE
use ReadmeAnyFromPod

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -21,8 +21,9 @@ exclude = warnings
 
 [Homepage]
 
-[ReadmeFromPod]
-[ReadmeMarkdownFromPod]
+[ReadmeAnyFromPod]
+[ReadmeAnyFromPod/MarkdownInBuild]
+
 [ReportVersions]
 
 [Repository]
@@ -41,5 +42,8 @@ tag_regexp = v(\d+[_.]\d+)
 tag_format  = v%v
 tag_message = Release %v.
 
-[@Classic]
+[@Filter]
+-bundle=@Classic
+-remove=Readme
+
 [MetaJSON]


### PR DESCRIPTION
This plugin prevents some warnings from using the ReadmeFromPod plugin,
and also provides the ReadmeMarkdownFromPod functionality in a single
module.

The warnings being generated by `dzil build` are:

```
->file called on a Dist::Zilla::Path object; this will cease to work in Dist::Zilla v7; downstream code should be updated to use Path::Tiny API, not Path::Class at /Users/doug/perl5/lib/perl5/Dist/Zilla/Plugin/ReadmeFromPod.pm line 87.
```

This is part of the CPAN Pull Request Challenge