### PR TITLE
fix wording in generated Changes file

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangelogFromGit.pm
+++ b/lib/Dist/Zilla/Plugin/ChangelogFromGit.pm
@@ -274,7 +274,7 @@ sub render_changelog_footer {
 	if ($skipped_count) {
 		my $releases = "release" . ($skipped_count == 1 ? "" : "s");
 		$changelog_footer = (
-			"Plus $skipped_count $releases after " .
+			"Plus $skipped_count $releases earlier than " .
 			$self->format_datetime($self->earliest_date()) . '.'
 		);
 	}


### PR DESCRIPTION
I think "before" would also be correct, but "earlier than" is less ambiguous, as arguably "after" could have been intended to mean "entries after this have been elided", rather than be temporal in nature.